### PR TITLE
Add copyright header to flask_compress.py

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2016 William Fagan
+Copyright (c) 2013-2017 William Fagan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/flask_compress.py
+++ b/flask_compress.py
@@ -1,3 +1,8 @@
+
+# Authors: William Fagan
+# Copyright (c) 2013-2017 William Fagan
+# License: The MIT License (MIT)
+
 import sys
 from gzip import GzipFile
 from io import BytesIO


### PR DESCRIPTION
This PR adds a copyright header to `flask_compress.py` and updates the copyright year.

Context: I would like to embed the `flask_compress.py` in the `externals` folder of my OSS project in order to limit the number of external dependencies and it would help if  `flask_compress.py` included a proper copyright header..

**Edit:** coveralls seems to be unhappy about the copyright, can't do much about that )