### PR TITLE
Fix indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ from flask_compress import Compress
 compress = Compress()
 
 def start_app():
-	app = Flask(__name__)
+    app = Flask(__name__)
     compress.init_app(app)
     return app
 ```


### PR DESCRIPTION
There was a tab instead of 4 spaces in an example, but the subsequent lines used spaces. Not a big deal, but still.