### PR TITLE
Fix caching mechanism.

### DIFF
--- a/flask_compress.py
+++ b/flask_compress.py
@@ -95,8 +95,10 @@ class Compress(object):
         response.direct_passthrough = False
 
         if self.cache:
-            key = self.cache_key(response)
-            gzip_content = self.cache.get(key) or self.compress(app, response)
+            key = self.cache_key(request)
+            gzip_content = self.cache.get(key)
+            if gzip_content is None:
+                gzip_content = self.compress(app, response)
             self.cache.set(key, gzip_content)
         else:
             gzip_content = self.compress(app, response)


### PR DESCRIPTION
Hi,

I used the request instead of the response in cache key callable and I also ensured that the cache works as expected without always compressing content.

Because the construct is as follows:

```python
self.cache.get(key) or self.compress(app, response)
```

The right part of the boolean statement is always evaluated.

With those two changes the cache works as expected for me and I can use a config like that:

```python
APP.config.update(
    COMPRESS_LEVEL=3,
    COMPRESS_CACHE_KEY=lambda x: x.full_path,
    COMPRESS_CACHE_BACKEND=DictCache,
)
```

Cheers,

Thomas